### PR TITLE
- remove load url from future

### DIFF
--- a/admin_extra_urls/templates/admin_extra_urls/change_form.html
+++ b/admin_extra_urls/templates/admin_extra_urls/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load extra_urls i18n admin_static admin_list admin_urls %}
-{% load url from future %}
 
 {% block object-tools %}
 

--- a/admin_extra_urls/templates/admin_extra_urls/change_list.html
+++ b/admin_extra_urls/templates/admin_extra_urls/change_list.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_list.html" %}
 {% load extra_urls i18n admin_static admin_list admin_urls %}
-{% load url from future %}
 
 {% block object-tools %}
 

--- a/admin_extra_urls/templates/admin_extra_urls/includes/change_form_buttons.html
+++ b/admin_extra_urls/templates/admin_extra_urls/includes/change_form_buttons.html
@@ -1,5 +1,4 @@
 {% load extra_urls i18n admin_static admin_list admin_urls %}
-{% load url from future %}
 
 {% for method_name, urlattrs in adminform.model_admin.extra_detail_buttons %}
     {% has_permission urlattrs.perm as authorized %}

--- a/admin_extra_urls/templates/admin_extra_urls/includes/change_list_buttons.html
+++ b/admin_extra_urls/templates/admin_extra_urls/includes/change_list_buttons.html
@@ -1,5 +1,4 @@
 {% load extra_urls i18n admin_static admin_list admin_urls %}
-{% load url from future %}
 
 {% for method_name,urlattrs in cl.model_admin.extra_buttons %}
     {% has_permission urlattrs.perm as authorized %}

--- a/admin_extra_urls/templates/admin_extra_urls/upload.html
+++ b/admin_extra_urls/templates/admin_extra_urls/upload.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}{% load i18n admin_static admin_list admin_urls suit_list suit_tags %}{% load url from future %}
+{% extends "admin/change_list.html" %}{% load i18n admin_static admin_list admin_urls suit_list suit_tags %}
 {% if not is_popup %}
     {% block breadcrumbs %}
         <ul class="breadcrumb">

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ ignore = E501,E401,W391,E128,E261,E731
 combine_as_imports = true
 default_section = THIRDPARTY
 include_trailing_comma = true
-known_first_party = wfp_eforms
+known_first_party = admin_extra_urls
 multi_line_output = 0
 line_length=100
 balanced_wrapping = true
@@ -31,3 +31,16 @@ tag_build =
 tag_date = 0
 tag_svn_revision = 0
 
+[pytest]
+DJANGO_SETTINGS_MODULE=demo.settings
+python_paths= . tests
+norecursedirs = data .tox
+addopts = -vvv
+        -p no:capturelog
+        -p no:xdist
+        -p no:pep8
+        --tb=short
+        --capture=no
+        --echo-version django
+        --echo-version pip
+        --echo-version admin_extra_urls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34}-{d16,d17,d18}
+envlist = {py27,py33,py34}-{d16,d17,d18,d19}
 
 [testenv]
 ;usedevelop=true
@@ -20,6 +20,7 @@ deps=
     d16: django>=1.6,<1.7
     d17: django>=1.7,<1.8
     d18: django>=1.8,<1.9
+    d19: django>=1.9,<1.10
     dev: git+git://github.com/django/django.git
 
 commands =


### PR DESCRIPTION
to make the library compatible to Django 1.9:

https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9

ssi and url template tags will be removed from the future template tag library (used during the 1.3/1.4 deprecation period).