### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,15 +127,15 @@ Links
                     :target: https://codecov.io/gh/saxix/django-admin-extra-urls
 
 
-.. |python| image:: https://pypip.in/py_versions/admin-extra-urls/badge.svg
+.. |python| image:: https://img.shields.io/pypi/pyversions/admin-extra-urls.svg
     :target: https://pypi.python.org/pypi/admin-extra-urls/
     :alt: Supported Python versions
 
-.. |pypi| image:: https://pypip.in/version/admin-extra-urls/badge.svg?text=version
+.. |pypi| image:: https://img.shields.io/pypi/v/admin-extra-urls.svg?label=version
     :target: https://pypi.python.org/pypi/admin-extra-urls/
     :alt: Latest Version
 
-.. |license| image:: https://pypip.in/license/admin-extra-urls/badge.svg
+.. |license| image:: https://img.shields.io/pypi/l/admin-extra-urls.svg
     :target: https://pypi.python.org/pypi/admin-extra-urls/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20admin-extra-urls))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `admin-extra-urls`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.