### PR TITLE
Fix non-default object query assumption in decorator

### DIFF
--- a/src/admin_extra_urls/decorators.py
+++ b/src/admin_extra_urls/decorators.py
@@ -71,7 +71,7 @@ def button(path=None, label=None, icon='', permission=None,
         def _inner(modeladmin, request, *args, **kwargs):
             if details:
                 pk = kwargs['pk']
-                obj = modeladmin.model.objects.get(pk=pk)
+                obj = modeladmin.get_object(request, pk)
                 url = reverse(admin_urlname(modeladmin.model._meta, 'change'),
                               args=[pk])
                 if permission:


### PR DESCRIPTION
Use the built-in modeladmin get_object function to get the object, rather than assume default model object structure.

If I have a custom task that uses a different manager, e.g.

```
class MyModel(models.Model):
   ...

   stuff = CustomManager()

```

This removes the default `objects` mapping. This change updates to use the modeladmin builtin function to get the object.

#24 
