### PR TITLE
Update the Readme to reflect preferred button decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ django-admin-extra-urls
     :align: center
 
 
-pluggable django application that offers one single mixin class ``ExtraUrlMixin``
+Pluggable django application that offers one single mixin class ``ExtraUrlMixin``
 to easily add new url (and related buttons on the screen) to any ModelAdmin.
 
-- ``action()`` decorator It will produce a button in the change form view.
+- ``button()`` decorator It will produce a button in the change form view.
 - ``href()`` to add button that point to external urls.
 
 
@@ -40,7 +40,6 @@ How to use it
     from admin_extra_urls import api as extras
 
     class MyModelModelAdmin(extras.ExtraUrlMixin, admin.ModelAdmin):
-        actions = ['smart_action']
 
         @extras.href(label='Search On Google', 'http://www.google.com?q={target}') # /admin/myapp/mymodel/update_all/
         def search_on_google(self, button):
@@ -57,25 +56,25 @@ How to use it
             return 'http://www.bing.com?q=target'
 
 
-        @extras.action() # /admin/myapp/mymodel/update_all/
+        @extras.button() # /admin/myapp/mymodel/update_all/
         def consolidate(self, request):
             ...
             ...
 
-        @extras.action() # /admin/myapp/mymodel/update/10/
+        @extras.button() # /admin/myapp/mymodel/update/10/
         def update(self, request, pk):
             # if we use `pk` in the args, the button will be in change_form
-            obj = self.get_object(pk=pk)
+            obj = self.get_object(request, pk)
             ...
 
-        @action(urls=[r'^aaa/(?P<pk>.*)/(?P<state>.*)/$',
+        @button(urls=[r'^aaa/(?P<pk>.*)/(?P<state>.*)/$',
                       r'^bbb/(?P<pk>.*)/$'])
         def revert(self, request, pk, state=None):
-            obj = self.get_object(pk=pk)
+            obj = self.get_object(request, pk)
             ...
 
 
-        @extras.action(label='Truncate', permission=lambda request, obj: request.user.is_superuser)
+        @extras.button(label='Truncate', permission=lambda request, obj: request.user.is_superuser)
         def truncate(self, request):
 
             if request.method == 'POST':
@@ -87,31 +86,30 @@ How to use it
 
 
 
-You don't need to return a HttpResponse. The default behavior is:
+If the return value from a `button` decorated method is a HttpResponse, that will be used.  Otherwise if the method contains the `pk` 
+argument user will be redirected to the 'update' view, otherwise and the browser will be redirected to the admin's list view
 
-    - if the  method contains the `pk` argument  button will be  displayed in the 'update' view and the browser will be redirected to ``change_view``
 
-
-action() options
+``button()`` options
 -------------------------
 
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| path       | None                 | path url path for the action. will be the url where the button will point to.          |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| label      | None                 | label for the button. by default the "labelized" function name                         |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| icon       | ''                   | icon for the button                                                                    |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| permission | None                 | permission required to use the button. Can be a callable (current object as argument). |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| css_class  | "btn btn-success"    | extra css classes to use for the button                                                |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| order      | 999                  | in case of multiple button the order to use                                            |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| visible    | lambda o: o and o.pk | callable or bool. By default do not display "action" button if in `add` mode           |
-+------------+----------------------+----------------------------------------------------------------------------------------+
-| urls       | None                 | list of urls to be linked to the action.                                               |
-+------------+----------------------+----------------------------------------------------------------------------------------+
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| path       | None                 | `path` url path for the button. Will be the url where the button will point to.         |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| label      | None                 | Label for the button. By default the "labelized" function name                          |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| icon       | ''                   | Icon for the button                                                                     |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| permission | None                 | Permission required to use the button. Can be a callable (current object as argument).  |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| css_class  | "btn btn-success"    | Extra css classes to use for the button                                                 |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| order      | 999                  | In case of multiple button the order to use                                             |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| visible    | lambda o: o and o.pk | callable or bool. By default do not display "action" button if in `add` mode            |
++------------+----------------------+-----------------------------------------------------------------------------------------+
+| urls       | None                 | list of urls to be linked to the action.                                                |
++------------+----------------------+------------------------------------------------------------------------------------------------+
 
 
 
@@ -125,20 +123,25 @@ django-import-export
 
     @admin.register(Rule)
     class RuleAdmin(ExtraUrlMixin, ImportExportMixin, BaseModelAdmin):
-        @action(label='Export')
+        @button(label='Export')
         def _export(self, request):
             if '_changelist_filters' in request.GET:
                 real_query = QueryDict(request.GET.get('_changelist_filters'))
                 request.GET = real_query
             return self.export_action(request)
 
-        @action(label='Import')
+        @button(label='Import')
         def _import(self, request):
             return self.import_action(request)
 
 
+Running project tests locally
+-----------------------------
+
+Install the dev dependencies with ``pip install -e '.[dev]'`` and then run tox.
+
 Links
-~~~~~
+-----
 
 +--------------------+----------------+--------------+-----------------------------+
 | Stable             | |master-build| | |master-cov| |                             |

--- a/src/admin_extra_urls/extras.py
+++ b/src/admin_extra_urls/extras.py
@@ -2,4 +2,4 @@ import warnings
 
 from .api import *  # noqa: F403, F401
 
-warnings.warn("extras is deprecated. Please use `from admon_extra_urls import api`", DeprecationWarning)
+warnings.warn("extras is deprecated. Please use `from admin_extra_urls import api`", DeprecationWarning)


### PR DESCRIPTION
Updates to the Readme to recommend using the button decorator instead of action.

I took some liberty to update the documentation to be slightly clearer in places, and to use sentence case. 

Happy to revert any changes, but thought this might be of help.